### PR TITLE
Remove email/password form from login page

### DIFF
--- a/components/authentication-page.tsx
+++ b/components/authentication-page.tsx
@@ -2,33 +2,13 @@
 
 import type React from "react"
 import { useState } from "react"
-import { useRouter } from "next/navigation"
-import { Eye, EyeOff, LogIn, Github } from "lucide-react"
+import { Github } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
 import { signIn } from "next-auth/react"
-import { Separator } from "@/components/ui/separator"
 
 export function AuthenticationPage() {
-  const router = useRouter()
-  const [showPassword, setShowPassword] = useState(false)
-  const [isLoading, setIsLoading] = useState(false)
   const [isGithubLoading, setIsGithubLoading] = useState(false)
-
-  const handleLogin = (e: React.FormEvent) => {
-    e.preventDefault()
-    setIsLoading(true)
-
-    // Simulate authentication process
-    setTimeout(() => {
-      // In a real app, you would verify credentials here
-      localStorage.setItem("isAuthenticated", "true")
-      router.push("/dashboard")
-      setIsLoading(false)
-    }, 1000)
-  }
 
   const handleGithubLogin = async () => {
     setIsGithubLoading(true)
@@ -70,50 +50,6 @@ export function AuthenticationPage() {
                 </>
               )}
             </Button>
-            
-            <div className="relative flex items-center">
-              <Separator className="flex-1" />
-              <span className="mx-2 text-xs text-muted-foreground">OR</span>
-              <Separator className="flex-1" />
-            </div>
-            
-            <form onSubmit={handleLogin}>
-              <div className="grid gap-4">
-                <div className="grid gap-2">
-                  <Label htmlFor="email">Email</Label>
-                  <Input id="email" type="email" placeholder="name@company.com" required />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="password">Password</Label>
-                  <div className="relative">
-                    <Input id="password" type={showPassword ? "text" : "password"} placeholder="••••••••" required />
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="absolute right-0 top-0 h-full px-3"
-                      onClick={() => setShowPassword(!showPassword)}
-                    >
-                      {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                      <span className="sr-only">{showPassword ? "Hide password" : "Show password"}</span>
-                    </Button>
-                  </div>
-                </div>
-                <Button type="submit" className="w-full" disabled={isLoading}>
-                  {isLoading ? (
-                    <div className="flex items-center gap-2">
-                      <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                      <span>Signing in...</span>
-                    </div>
-                  ) : (
-                    <div className="flex items-center gap-2">
-                      <LogIn className="h-4 w-4" />
-                      <span>Sign In</span>
-                    </div>
-                  )}
-                </Button>
-              </div>
-            </form>
           </div>
         </CardContent>
         <CardFooter className="flex flex-col">


### PR DESCRIPTION
This PR removes the email/password form from the login page, as users should only be able to access the app with GitHub OAuth login.

Changes:
- Removed email/password form from the authentication page
- Removed password visibility toggle
- Removed email input field
- Simplified the UI to only show the GitHub login button
- Preserved the terms and privacy links in the footer

The login page now has a cleaner and more straightforward user experience, only allowing users to log in with GitHub.